### PR TITLE
redis security group  optimize.

### DIFF
--- a/example/nosql/redis/test_redis.go
+++ b/example/nosql/redis/test_redis.go
@@ -35,6 +35,7 @@ func CreateCacheCluster() {
 	form["VpcId"] = "vpcId"
 	form["VnetId"] = "vnetId"
 	form["Protocol"] = "4.0"
+	form["SecurityGroupId"] = "10086"
 	nosql.ProcessResult(v1.CreateCacheCluster(&form))
 }
 
@@ -49,18 +50,6 @@ func CreateCacheParameterGroup() {
 	form["Parameters.ParameterName.2"] = "appendonly"
 	form["Parameters.ParameterValue.2"] = "yes"
 	nosql.ProcessResult(v1.CreateCacheParameterGroup(&form))
-}
-
-func CreateCacheSecurityGroup() {
-	form := make(map[string]interface{})
-	form["AvailableZone"] = "az"
-	form["Engine"] = "redis"
-	form["CacheId"] = "cacheId"
-	form["Name"] = "myRedisParamGroup"
-	form["Description"] = "myRedisParamGroup"
-	form["SecurityGroupRules.Cidr.1"] = "192.168.18.17/21"
-	form["SecurityGroupRules.Cidr.2"] = "192.168.18.18/21"
-	nosql.ProcessResult(v1.CreateCacheSecurityGroup(&form))
 }
 
 func CreateSnapshot() {
@@ -86,32 +75,6 @@ func DeleteCacheParameterGroup() {
 	form["Engine"] = "redis"
 	form["CacheParameterGroupId"] = "123123"
 	nosql.ProcessResult(v1.DeleteCacheParameterGroup(&form))
-}
-
-func DeleteCacheSecurityGroup() {
-	form := make(map[string]interface{})
-	form["AvailableZone"] = "az"
-	form["Engine"] = "redis"
-	form["CacheSecurityGroupId"] = "123123"
-	nosql.ProcessResult(v1.DeleteCacheSecurityGroup(&form))
-}
-
-func DeleteCacheSecurityGroupRule() {
-	form := make(map[string]interface{})
-	form["AvailableZone"] = "az"
-	form["Engine"] = "redis"
-	form["CacheSecurityGroupId"] = "123123"
-	form["SecurityRuleId"] = "123123"
-	nosql.ProcessResult(v1.DeleteCacheSecurityGroupRule(&form))
-}
-
-func DeleteCacheSecurityRule() {
-	form := make(map[string]interface{})
-	form["AvailableZone"] = "az"
-	form["Engine"] = "redis"
-	form["CacheId"] = "cacheId"
-	form["SecurityRuleId"] = "123123"
-	nosql.ProcessResult(v1.DeleteCacheSecurityRule(&form))
 }
 
 func DeleteSnapshot() {
@@ -174,29 +137,6 @@ func DescribeCacheParameters() {
 	nosql.ProcessResult(v1.DescribeCacheParameters(&form))
 }
 
-func DescribeCacheSecurityGroup() {
-	form := make(map[string]interface{})
-	form["AvailableZone"] = "az"
-	form["Engine"] = "redis"
-	form["CacheSecurityGroupId"] = "1212"
-	nosql.ProcessResult(v1.DescribeCacheSecurityGroup(&form))
-}
-
-func DescribeCacheSecurityGroups() {
-	form := make(map[string]interface{})
-	form["AvailableZone"] = "az"
-	form["Engine"] = "redis"
-	nosql.ProcessResult(v1.DescribeCacheSecurityGroups(&form))
-}
-
-func DescribeCacheSecurityRules() {
-	form := make(map[string]interface{})
-	form["AvailableZone"] = "az"
-	form["Engine"] = "redis"
-	form["CacheId"] = "cacheId"
-	nosql.ProcessResult(v1.DescribeCacheSecurityRules(&form))
-}
-
 func DescribeRegions() {
 	nosql.ProcessResult(v1.DescribeRegions(nil))
 }
@@ -247,19 +187,6 @@ func ModifyCacheParameterGroup() {
 	form["Parameters.ParameterName.2"] = "appendonly"
 	form["Parameters.ParameterValue.2"] = "yes"
 	nosql.ProcessResult(v1.ModifyCacheParameterGroup(&form))
-}
-
-func ModifyCacheSecurityGroup() {
-	form := make(map[string]interface{})
-	form["AvailableZone"] = "az"
-	form["Engine"] = "redis"
-	form["CacheId"] = "cacheId"
-	form["Name"] = "myRedisParamGroup"
-	form["CacheSecurityGroupId"] = "1231"
-	form["Description"] = "myRedisParamGroup"
-	form["SecurityGroupRules.Cidr.1"] = "192.168.18.17/21"
-	form["SecurityGroupRules.Cidr.2"] = "192.168.18.18/21"
-	nosql.ProcessResult(v1.ModifyCacheSecurityGroup(&form))
 }
 
 func RenameCacheCluster() {
@@ -319,25 +246,6 @@ func SetCacheParameters() {
 	nosql.ProcessResult(v1.SetCacheParameters(&form))
 }
 
-func SetCacheSecurityGroup() {
-	form := make(map[string]interface{})
-	form["AvailableZone"] = "az"
-	form["Engine"] = "redis"
-	form["CacheId"] = "cacheId"
-	form["CacheSecurityGroupId"] = "122"
-	nosql.ProcessResult(v1.SetCacheSecurityGroup(&form))
-}
-
-func SetCacheSecurityRules() {
-	form := make(map[string]interface{})
-	form["AvailableZone"] = "az"
-	form["Engine"] = "redis"
-	form["CacheId"] = "cacheId"
-	form["SecurityGroupRules.Cidr.1"] = "192.168.18.17/21"
-	form["SecurityGroupRules.Cidr.2"] = "192.168.18.18/21"
-	nosql.ProcessResult(v1.SetCacheSecurityRules(&form))
-}
-
 func SetTimingSnapshot() {
 	form := make(map[string]interface{})
 	form["AvailableZone"] = "az"
@@ -383,17 +291,105 @@ func UpdatePassword() {
 	nosql.ProcessResult(v1.UpdatePassword(&form))
 }
 
+func CreateSecurityGroup() {
+	form := make(map[string]interface{})
+	form["AvailableZone"] = "az"
+	form["Name"] = "testGoSdk"
+	form["Description"] = "testGoSdk"
+	nosql.ProcessResult(v1.CreateSecurityGroup(&form))
+}
+
+func CloneSecurityGroup() {
+	form := make(map[string]interface{})
+	form["AvailableZone"] = "az"
+	form["Name"] = "testGoSdkClone"
+	form["Description"] = "testGoSdkClone"
+	form["SrcSecurityGroupId"] = "srcSecurityGroupId"
+	nosql.ProcessResult(v1.CloneSecurityGroup(&form))
+}
+
+func DeleteSecurityGroup() {
+	form := make(map[string]interface{})
+	form["AvailableZone"] = "az"
+	form["SecurityGroupId.1"] = "securityGroupId"
+	nosql.ProcessResult(v1.DeleteSecurityGroup(&form))
+}
+
+func ModifySecurityGroup() {
+	form := make(map[string]interface{})
+	form["AvailableZone"] = "az"
+	form["Name"] = "testGoSdkClone777"
+	form["Description"] = "testGoSdkClone777"
+	form["SecurityGroupId"] = "securityGroupId"
+	nosql.ProcessResult(v1.ModifySecurityGroup(&form))
+}
+
+func DescribeSecurityGroups() {
+	form := make(map[string]interface{})
+	form["AvailableZone"] = "az"
+	nosql.ProcessResult(v1.DescribeSecurityGroups(&form))
+}
+
+func DescribeSecurityGroup() {
+	form := make(map[string]interface{})
+	form["AvailableZone"] = "az"
+	form["SecurityGroupId"] = "securityGroupId"
+	nosql.ProcessResult(v1.DescribeSecurityGroup(&form))
+}
+
+func AllocateSecurityGroup() {
+	form := make(map[string]interface{})
+	form["AvailableZone"] = "az"
+	form["CacheId.1"] = "cacheId"
+	form["SecurityGroupId.1"] = "securityGroupId"
+	nosql.ProcessResult(v1.AllocateSecurityGroup(&form))
+}
+
+func DeallocateSecurityGroup() {
+	form := make(map[string]interface{})
+	form["AvailableZone"] = "az"
+	form["CacheId.1"] = "cacheId"
+	form["SecurityGroupId"] = "securityGroupId"
+	nosql.ProcessResult(v1.DeallocateSecurityGroup(&form))
+}
+
+func CreateSecurityGroupRule() {
+	form := make(map[string]interface{})
+	form["AvailableZone"] = "az"
+	form["SecurityGroupId"] = "securityGroupId"
+	form["Cidrs.1"] = "172.11.14.0/16"
+	nosql.ProcessResult(v1.CreateSecurityGroupRule(&form))
+}
+
+func DeleteSecurityGroupRule() {
+	form := make(map[string]interface{})
+	form["AvailableZone"] = "az"
+	form["SecurityGroupId"] = "securityGroupId"
+	form["SecurityGroupRuleId.1"] = "securityGroupRuleId"
+	nosql.ProcessResult(v1.DeleteSecurityGroupRule(&form))
+}
+
+func DescribeInstances() {
+	form := make(map[string]interface{})
+	form["AvailableZone"] = "az"
+	form["SecurityGroupId"] = "securityGroupId"
+	nosql.ProcessResult(v1.DescribeInstances(&form))
+}
+
 func main() {
+	AllocateSecurityGroup()
 	CreateCacheCluster()
 	CreateCacheParameterGroup()
-	CreateCacheSecurityGroup()
+	CreateSecurityGroup()
+	CloneSecurityGroup()
+	CreateSecurityGroupRule()
 	CreateSnapshot()
 	DeleteCacheCluster()
 	DeleteCacheParameterGroup()
-	DeleteCacheSecurityGroup()
-	DeleteCacheSecurityGroupRule()
-	DeleteCacheSecurityRule()
+	DeleteSecurityGroup()
+	DeleteSecurityGroupRule()
 	DeleteSnapshot()
+	DeallocateSecurityGroup()
 	DescribeAvailabilityZones()
 	DescribeCacheCluster()
 	DescribeCacheClusters()
@@ -401,24 +397,22 @@ func main() {
 	DescribeCacheParameterGroup()
 	DescribeCacheParameterGroups()
 	DescribeCacheParameters()
-	DescribeCacheSecurityGroup()
-	DescribeCacheSecurityGroups()
-	DescribeCacheSecurityRules()
+	DescribeInstances()
+	DescribeSecurityGroups()
+	DescribeSecurityGroup()
 	DescribeRegions()
 	DescribeSnapshots()
 	DownloadSnapshot()
 	ExportSnapshot()
 	FlushCacheCluster()
+	ModifySecurityGroup()
 	ModifyCacheParameterGroup()
-	ModifyCacheSecurityGroup()
 	RenameCacheCluster()
 	RenameSnapshot()
 	ResizeCacheCluster()
 	RestoreSnapshot()
 	SetCacheParameterGroup()
 	SetCacheParameters()
-	SetCacheSecurityGroup()
-	SetCacheSecurityRules()
 	SetTimingSnapshot()
 	AddCacheSlaveNode()
 	DeleteCacheSlaveNode()

--- a/service/kcsv1/api.go
+++ b/service/kcsv1/api.go
@@ -7,6 +7,152 @@ import (
 	"github.com/aws/aws-sdk-go/aws/request"
 )
 
+const opAllocateSecurityGroup = "AllocateSecurityGroup"
+
+// AllocateSecurityGroupRequest generates a "ksc/request.Request" representing the
+// client's request for the AllocateSecurityGroup operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See AllocateSecurityGroup for more information on using the AllocateSecurityGroup
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the AllocateSecurityGroupRequest method.
+//    req, resp := client.AllocateSecurityGroupRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/kcs-2016-07-01/AllocateSecurityGroup
+func (c *Kcsv1) AllocateSecurityGroupRequest(input *map[string]interface{}) (req *request.Request, output *map[string]interface{}) {
+	op := &request.Operation{
+		Name:       opAllocateSecurityGroup,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &map[string]interface{}{}
+	}
+
+	output = &map[string]interface{}{}
+	req = c.newRequest(op, input, output)
+
+	return
+}
+
+// AllocateSecurityGroup API operation for kcsv1.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the KSC API reference guide for kcsv1's
+// API operation AllocateSecurityGroup for usage and error information.
+// See also, https://docs.aws.amazon.com/goto/WebAPI/kcs-2016-07-01/AllocateSecurityGroup
+func (c *Kcsv1) AllocateSecurityGroup(input *map[string]interface{}) (*map[string]interface{}, error) {
+	req, out := c.AllocateSecurityGroupRequest(input)
+	return out, req.Send()
+}
+
+// AllocateSecurityGroupWithContext is the same as AllocateSecurityGroup with the addition of
+// the ability to pass a context and additional request options.
+//
+// See AllocateSecurityGroup for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *Kcsv1) AllocateSecurityGroupWithContext(ctx aws.Context, input *map[string]interface{}, opts ...request.Option) (*map[string]interface{}, error) {
+	req, out := c.AllocateSecurityGroupRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opCloneSecurityGroup = "CloneSecurityGroup"
+
+// CloneSecurityGroupRequest generates a "ksc/request.Request" representing the
+// client's request for the CloneSecurityGroup operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See CloneSecurityGroup for more information on using the CloneSecurityGroup
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the CloneSecurityGroupRequest method.
+//    req, resp := client.CloneSecurityGroupRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/kcs-2016-07-01/CloneSecurityGroup
+func (c *Kcsv1) CloneSecurityGroupRequest(input *map[string]interface{}) (req *request.Request, output *map[string]interface{}) {
+	op := &request.Operation{
+		Name:       opCloneSecurityGroup,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &map[string]interface{}{}
+	}
+
+	output = &map[string]interface{}{}
+	req = c.newRequest(op, input, output)
+
+	return
+}
+
+// CloneSecurityGroup API operation for kcsv1.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the KSC API reference guide for kcsv1's
+// API operation CloneSecurityGroup for usage and error information.
+// See also, https://docs.aws.amazon.com/goto/WebAPI/kcs-2016-07-01/CloneSecurityGroup
+func (c *Kcsv1) CloneSecurityGroup(input *map[string]interface{}) (*map[string]interface{}, error) {
+	req, out := c.CloneSecurityGroupRequest(input)
+	return out, req.Send()
+}
+
+// CloneSecurityGroupWithContext is the same as CloneSecurityGroup with the addition of
+// the ability to pass a context and additional request options.
+//
+// See CloneSecurityGroup for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *Kcsv1) CloneSecurityGroupWithContext(ctx aws.Context, input *map[string]interface{}, opts ...request.Option) (*map[string]interface{}, error) {
+	req, out := c.CloneSecurityGroupRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opCreateCacheCluster = "CreateCacheCluster"
 
 // CreateCacheClusterRequest generates a "ksc/request.Request" representing the
@@ -153,35 +299,35 @@ func (c *Kcsv1) CreateCacheParameterGroupWithContext(ctx aws.Context, input *map
 	return out, req.Send()
 }
 
-const opCreateCacheSecurityGroup = "CreateCacheSecurityGroup"
+const opCreateSecurityGroup = "CreateSecurityGroup"
 
-// CreateCacheSecurityGroupRequest generates a "ksc/request.Request" representing the
-// client's request for the CreateCacheSecurityGroup operation. The "output" return
+// CreateSecurityGroupRequest generates a "ksc/request.Request" representing the
+// client's request for the CreateSecurityGroup operation. The "output" return
 // value will be populated with the request's response once the request completes
 // successfully.
 //
 // Use "Send" method on the returned Request to send the API call to the service.
 // the "output" return value is not valid until after Send returns without error.
 //
-// See CreateCacheSecurityGroup for more information on using the CreateCacheSecurityGroup
+// See CreateSecurityGroup for more information on using the CreateSecurityGroup
 // API call, and error handling.
 //
 // This method is useful when you want to inject custom logic or configuration
 // into the SDK's request lifecycle. Such as custom headers, or retry logic.
 //
 //
-//    // Example sending a request using the CreateCacheSecurityGroupRequest method.
-//    req, resp := client.CreateCacheSecurityGroupRequest(params)
+//    // Example sending a request using the CreateSecurityGroupRequest method.
+//    req, resp := client.CreateSecurityGroupRequest(params)
 //
 //    err := req.Send()
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/kcs-2016-07-01/CreateCacheSecurityGroup
-func (c *Kcsv1) CreateCacheSecurityGroupRequest(input *map[string]interface{}) (req *request.Request, output *map[string]interface{}) {
+// See also, https://docs.aws.amazon.com/goto/WebAPI/kcs-2016-07-01/CreateSecurityGroup
+func (c *Kcsv1) CreateSecurityGroupRequest(input *map[string]interface{}) (req *request.Request, output *map[string]interface{}) {
 	op := &request.Operation{
-		Name:       opCreateCacheSecurityGroup,
+		Name:       opCreateSecurityGroup,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
 	}
@@ -196,31 +342,104 @@ func (c *Kcsv1) CreateCacheSecurityGroupRequest(input *map[string]interface{}) (
 	return
 }
 
-// CreateCacheSecurityGroup API operation for kcsv1.
+// CreateSecurityGroup API operation for kcsv1.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
 // the error.
 //
 // See the KSC API reference guide for kcsv1's
-// API operation CreateCacheSecurityGroup for usage and error information.
-// See also, https://docs.aws.amazon.com/goto/WebAPI/kcs-2016-07-01/CreateCacheSecurityGroup
-func (c *Kcsv1) CreateCacheSecurityGroup(input *map[string]interface{}) (*map[string]interface{}, error) {
-	req, out := c.CreateCacheSecurityGroupRequest(input)
+// API operation CreateSecurityGroup for usage and error information.
+// See also, https://docs.aws.amazon.com/goto/WebAPI/kcs-2016-07-01/CreateSecurityGroup
+func (c *Kcsv1) CreateSecurityGroup(input *map[string]interface{}) (*map[string]interface{}, error) {
+	req, out := c.CreateSecurityGroupRequest(input)
 	return out, req.Send()
 }
 
-// CreateCacheSecurityGroupWithContext is the same as CreateCacheSecurityGroup with the addition of
+// CreateSecurityGroupWithContext is the same as CreateSecurityGroup with the addition of
 // the ability to pass a context and additional request options.
 //
-// See CreateCacheSecurityGroup for details on how to use this API operation.
+// See CreateSecurityGroup for details on how to use this API operation.
 //
 // The context must be non-nil and will be used for request cancellation. If
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *Kcsv1) CreateCacheSecurityGroupWithContext(ctx aws.Context, input *map[string]interface{}, opts ...request.Option) (*map[string]interface{}, error) {
-	req, out := c.CreateCacheSecurityGroupRequest(input)
+func (c *Kcsv1) CreateSecurityGroupWithContext(ctx aws.Context, input *map[string]interface{}, opts ...request.Option) (*map[string]interface{}, error) {
+	req, out := c.CreateSecurityGroupRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opCreateSecurityGroupRule = "CreateSecurityGroupRule"
+
+// CreateSecurityGroupRuleRequest generates a "ksc/request.Request" representing the
+// client's request for the CreateSecurityGroupRule operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See CreateSecurityGroupRule for more information on using the CreateSecurityGroupRule
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the CreateSecurityGroupRuleRequest method.
+//    req, resp := client.CreateSecurityGroupRuleRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/kcs-2016-07-01/CreateSecurityGroupRule
+func (c *Kcsv1) CreateSecurityGroupRuleRequest(input *map[string]interface{}) (req *request.Request, output *map[string]interface{}) {
+	op := &request.Operation{
+		Name:       opCreateSecurityGroupRule,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &map[string]interface{}{}
+	}
+
+	output = &map[string]interface{}{}
+	req = c.newRequest(op, input, output)
+
+	return
+}
+
+// CreateSecurityGroupRule API operation for kcsv1.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the KSC API reference guide for kcsv1's
+// API operation CreateSecurityGroupRule for usage and error information.
+// See also, https://docs.aws.amazon.com/goto/WebAPI/kcs-2016-07-01/CreateSecurityGroupRule
+func (c *Kcsv1) CreateSecurityGroupRule(input *map[string]interface{}) (*map[string]interface{}, error) {
+	req, out := c.CreateSecurityGroupRuleRequest(input)
+	return out, req.Send()
+}
+
+// CreateSecurityGroupRuleWithContext is the same as CreateSecurityGroupRule with the addition of
+// the ability to pass a context and additional request options.
+//
+// See CreateSecurityGroupRule for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *Kcsv1) CreateSecurityGroupRuleWithContext(ctx aws.Context, input *map[string]interface{}, opts ...request.Option) (*map[string]interface{}, error) {
+	req, out := c.CreateSecurityGroupRuleRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -294,6 +513,79 @@ func (c *Kcsv1) CreateSnapshot(input *map[string]interface{}) (*map[string]inter
 // for more information on using Contexts.
 func (c *Kcsv1) CreateSnapshotWithContext(ctx aws.Context, input *map[string]interface{}, opts ...request.Option) (*map[string]interface{}, error) {
 	req, out := c.CreateSnapshotRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opDeallocateSecurityGroup = "DeallocateSecurityGroup"
+
+// DeallocateSecurityGroupRequest generates a "ksc/request.Request" representing the
+// client's request for the DeallocateSecurityGroup operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DeallocateSecurityGroup for more information on using the DeallocateSecurityGroup
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DeallocateSecurityGroupRequest method.
+//    req, resp := client.DeallocateSecurityGroupRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/kcs-2016-07-01/DeallocateSecurityGroup
+func (c *Kcsv1) DeallocateSecurityGroupRequest(input *map[string]interface{}) (req *request.Request, output *map[string]interface{}) {
+	op := &request.Operation{
+		Name:       opDeallocateSecurityGroup,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &map[string]interface{}{}
+	}
+
+	output = &map[string]interface{}{}
+	req = c.newRequest(op, input, output)
+
+	return
+}
+
+// DeallocateSecurityGroup API operation for kcsv1.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the KSC API reference guide for kcsv1's
+// API operation DeallocateSecurityGroup for usage and error information.
+// See also, https://docs.aws.amazon.com/goto/WebAPI/kcs-2016-07-01/DeallocateSecurityGroup
+func (c *Kcsv1) DeallocateSecurityGroup(input *map[string]interface{}) (*map[string]interface{}, error) {
+	req, out := c.DeallocateSecurityGroupRequest(input)
+	return out, req.Send()
+}
+
+// DeallocateSecurityGroupWithContext is the same as DeallocateSecurityGroup with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DeallocateSecurityGroup for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *Kcsv1) DeallocateSecurityGroupWithContext(ctx aws.Context, input *map[string]interface{}, opts ...request.Option) (*map[string]interface{}, error) {
+	req, out := c.DeallocateSecurityGroupRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -445,36 +737,36 @@ func (c *Kcsv1) DeleteCacheParameterGroupWithContext(ctx aws.Context, input *map
 	return out, req.Send()
 }
 
-const opDeleteCacheSecurityGroup = "DeleteCacheSecurityGroup"
+const opDeleteSecurityGroup = "DeleteSecurityGroup"
 
-// DeleteCacheSecurityGroupRequest generates a "ksc/request.Request" representing the
-// client's request for the DeleteCacheSecurityGroup operation. The "output" return
+// DeleteSecurityGroupRequest generates a "ksc/request.Request" representing the
+// client's request for the DeleteSecurityGroup operation. The "output" return
 // value will be populated with the request's response once the request completes
 // successfully.
 //
 // Use "Send" method on the returned Request to send the API call to the service.
 // the "output" return value is not valid until after Send returns without error.
 //
-// See DeleteCacheSecurityGroup for more information on using the DeleteCacheSecurityGroup
+// See DeleteSecurityGroup for more information on using the DeleteSecurityGroup
 // API call, and error handling.
 //
 // This method is useful when you want to inject custom logic or configuration
 // into the SDK's request lifecycle. Such as custom headers, or retry logic.
 //
 //
-//    // Example sending a request using the DeleteCacheSecurityGroupRequest method.
-//    req, resp := client.DeleteCacheSecurityGroupRequest(params)
+//    // Example sending a request using the DeleteSecurityGroupRequest method.
+//    req, resp := client.DeleteSecurityGroupRequest(params)
 //
 //    err := req.Send()
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/kcs-2016-07-01/DeleteCacheSecurityGroup
-func (c *Kcsv1) DeleteCacheSecurityGroupRequest(input *map[string]interface{}) (req *request.Request, output *map[string]interface{}) {
+// See also, https://docs.aws.amazon.com/goto/WebAPI/kcs-2016-07-01/DeleteSecurityGroup
+func (c *Kcsv1) DeleteSecurityGroupRequest(input *map[string]interface{}) (req *request.Request, output *map[string]interface{}) {
 	op := &request.Operation{
-		Name:       opDeleteCacheSecurityGroup,
-		HTTPMethod: "DELETE",
+		Name:       opDeleteSecurityGroup,
+		HTTPMethod: "POST",
 		HTTPPath:   "/",
 	}
 
@@ -488,66 +780,66 @@ func (c *Kcsv1) DeleteCacheSecurityGroupRequest(input *map[string]interface{}) (
 	return
 }
 
-// DeleteCacheSecurityGroup API operation for kcsv1.
+// DeleteSecurityGroup API operation for kcsv1.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
 // the error.
 //
 // See the KSC API reference guide for kcsv1's
-// API operation DeleteCacheSecurityGroup for usage and error information.
-// See also, https://docs.aws.amazon.com/goto/WebAPI/kcs-2016-07-01/DeleteCacheSecurityGroup
-func (c *Kcsv1) DeleteCacheSecurityGroup(input *map[string]interface{}) (*map[string]interface{}, error) {
-	req, out := c.DeleteCacheSecurityGroupRequest(input)
+// API operation DeleteSecurityGroup for usage and error information.
+// See also, https://docs.aws.amazon.com/goto/WebAPI/kcs-2016-07-01/DeleteSecurityGroup
+func (c *Kcsv1) DeleteSecurityGroup(input *map[string]interface{}) (*map[string]interface{}, error) {
+	req, out := c.DeleteSecurityGroupRequest(input)
 	return out, req.Send()
 }
 
-// DeleteCacheSecurityGroupWithContext is the same as DeleteCacheSecurityGroup with the addition of
+// DeleteSecurityGroupWithContext is the same as DeleteSecurityGroup with the addition of
 // the ability to pass a context and additional request options.
 //
-// See DeleteCacheSecurityGroup for details on how to use this API operation.
+// See DeleteSecurityGroup for details on how to use this API operation.
 //
 // The context must be non-nil and will be used for request cancellation. If
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *Kcsv1) DeleteCacheSecurityGroupWithContext(ctx aws.Context, input *map[string]interface{}, opts ...request.Option) (*map[string]interface{}, error) {
-	req, out := c.DeleteCacheSecurityGroupRequest(input)
+func (c *Kcsv1) DeleteSecurityGroupWithContext(ctx aws.Context, input *map[string]interface{}, opts ...request.Option) (*map[string]interface{}, error) {
+	req, out := c.DeleteSecurityGroupRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
 }
 
-const opDeleteCacheSecurityGroupRule = "DeleteCacheSecurityGroupRule"
+const opDeleteSecurityGroupRule = "DeleteSecurityGroupRule"
 
-// DeleteCacheSecurityGroupRuleRequest generates a "ksc/request.Request" representing the
-// client's request for the DeleteCacheSecurityGroupRule operation. The "output" return
+// DeleteSecurityGroupRuleRequest generates a "ksc/request.Request" representing the
+// client's request for the DeleteSecurityGroupRule operation. The "output" return
 // value will be populated with the request's response once the request completes
 // successfully.
 //
 // Use "Send" method on the returned Request to send the API call to the service.
 // the "output" return value is not valid until after Send returns without error.
 //
-// See DeleteCacheSecurityGroupRule for more information on using the DeleteCacheSecurityGroupRule
+// See DeleteSecurityGroupRule for more information on using the DeleteSecurityGroupRule
 // API call, and error handling.
 //
 // This method is useful when you want to inject custom logic or configuration
 // into the SDK's request lifecycle. Such as custom headers, or retry logic.
 //
 //
-//    // Example sending a request using the DeleteCacheSecurityGroupRuleRequest method.
-//    req, resp := client.DeleteCacheSecurityGroupRuleRequest(params)
+//    // Example sending a request using the DeleteSecurityGroupRuleRequest method.
+//    req, resp := client.DeleteSecurityGroupRuleRequest(params)
 //
 //    err := req.Send()
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/kcs-2016-07-01/DeleteCacheSecurityGroupRule
-func (c *Kcsv1) DeleteCacheSecurityGroupRuleRequest(input *map[string]interface{}) (req *request.Request, output *map[string]interface{}) {
+// See also, https://docs.aws.amazon.com/goto/WebAPI/kcs-2016-07-01/DeleteSecurityGroupRule
+func (c *Kcsv1) DeleteSecurityGroupRuleRequest(input *map[string]interface{}) (req *request.Request, output *map[string]interface{}) {
 	op := &request.Operation{
-		Name:       opDeleteCacheSecurityGroupRule,
-		HTTPMethod: "DELETE",
+		Name:       opDeleteSecurityGroupRule,
+		HTTPMethod: "POST",
 		HTTPPath:   "/",
 	}
 
@@ -561,104 +853,31 @@ func (c *Kcsv1) DeleteCacheSecurityGroupRuleRequest(input *map[string]interface{
 	return
 }
 
-// DeleteCacheSecurityGroupRule API operation for kcsv1.
+// DeleteSecurityGroupRule API operation for kcsv1.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
 // the error.
 //
 // See the KSC API reference guide for kcsv1's
-// API operation DeleteCacheSecurityGroupRule for usage and error information.
-// See also, https://docs.aws.amazon.com/goto/WebAPI/kcs-2016-07-01/DeleteCacheSecurityGroupRule
-func (c *Kcsv1) DeleteCacheSecurityGroupRule(input *map[string]interface{}) (*map[string]interface{}, error) {
-	req, out := c.DeleteCacheSecurityGroupRuleRequest(input)
+// API operation DeleteSecurityGroupRule for usage and error information.
+// See also, https://docs.aws.amazon.com/goto/WebAPI/kcs-2016-07-01/DeleteSecurityGroupRule
+func (c *Kcsv1) DeleteSecurityGroupRule(input *map[string]interface{}) (*map[string]interface{}, error) {
+	req, out := c.DeleteSecurityGroupRuleRequest(input)
 	return out, req.Send()
 }
 
-// DeleteCacheSecurityGroupRuleWithContext is the same as DeleteCacheSecurityGroupRule with the addition of
+// DeleteSecurityGroupRuleWithContext is the same as DeleteSecurityGroupRule with the addition of
 // the ability to pass a context and additional request options.
 //
-// See DeleteCacheSecurityGroupRule for details on how to use this API operation.
+// See DeleteSecurityGroupRule for details on how to use this API operation.
 //
 // The context must be non-nil and will be used for request cancellation. If
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *Kcsv1) DeleteCacheSecurityGroupRuleWithContext(ctx aws.Context, input *map[string]interface{}, opts ...request.Option) (*map[string]interface{}, error) {
-	req, out := c.DeleteCacheSecurityGroupRuleRequest(input)
-	req.SetContext(ctx)
-	req.ApplyOptions(opts...)
-	return out, req.Send()
-}
-
-const opDeleteCacheSecurityRule = "DeleteCacheSecurityRule"
-
-// DeleteCacheSecurityRuleRequest generates a "ksc/request.Request" representing the
-// client's request for the DeleteCacheSecurityRule operation. The "output" return
-// value will be populated with the request's response once the request completes
-// successfully.
-//
-// Use "Send" method on the returned Request to send the API call to the service.
-// the "output" return value is not valid until after Send returns without error.
-//
-// See DeleteCacheSecurityRule for more information on using the DeleteCacheSecurityRule
-// API call, and error handling.
-//
-// This method is useful when you want to inject custom logic or configuration
-// into the SDK's request lifecycle. Such as custom headers, or retry logic.
-//
-//
-//    // Example sending a request using the DeleteCacheSecurityRuleRequest method.
-//    req, resp := client.DeleteCacheSecurityRuleRequest(params)
-//
-//    err := req.Send()
-//    if err == nil { // resp is now filled
-//        fmt.Println(resp)
-//    }
-//
-// See also, https://docs.aws.amazon.com/goto/WebAPI/kcs-2016-07-01/DeleteCacheSecurityRule
-func (c *Kcsv1) DeleteCacheSecurityRuleRequest(input *map[string]interface{}) (req *request.Request, output *map[string]interface{}) {
-	op := &request.Operation{
-		Name:       opDeleteCacheSecurityRule,
-		HTTPMethod: "DELETE",
-		HTTPPath:   "/",
-	}
-
-	if input == nil {
-		input = &map[string]interface{}{}
-	}
-
-	output = &map[string]interface{}{}
-	req = c.newRequest(op, input, output)
-
-	return
-}
-
-// DeleteCacheSecurityRule API operation for kcsv1.
-//
-// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
-// with awserr.Error's Code and Message methods to get detailed information about
-// the error.
-//
-// See the KSC API reference guide for kcsv1's
-// API operation DeleteCacheSecurityRule for usage and error information.
-// See also, https://docs.aws.amazon.com/goto/WebAPI/kcs-2016-07-01/DeleteCacheSecurityRule
-func (c *Kcsv1) DeleteCacheSecurityRule(input *map[string]interface{}) (*map[string]interface{}, error) {
-	req, out := c.DeleteCacheSecurityRuleRequest(input)
-	return out, req.Send()
-}
-
-// DeleteCacheSecurityRuleWithContext is the same as DeleteCacheSecurityRule with the addition of
-// the ability to pass a context and additional request options.
-//
-// See DeleteCacheSecurityRule for details on how to use this API operation.
-//
-// The context must be non-nil and will be used for request cancellation. If
-// the context is nil a panic will occur. In the future the SDK may create
-// sub-contexts for http.Requests. See https://golang.org/pkg/context/
-// for more information on using Contexts.
-func (c *Kcsv1) DeleteCacheSecurityRuleWithContext(ctx aws.Context, input *map[string]interface{}, opts ...request.Option) (*map[string]interface{}, error) {
-	req, out := c.DeleteCacheSecurityRuleRequest(input)
+func (c *Kcsv1) DeleteSecurityGroupRuleWithContext(ctx aws.Context, input *map[string]interface{}, opts ...request.Option) (*map[string]interface{}, error) {
+	req, out := c.DeleteSecurityGroupRuleRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -1248,35 +1467,35 @@ func (c *Kcsv1) DescribeCacheParametersWithContext(ctx aws.Context, input *map[s
 	return out, req.Send()
 }
 
-const opDescribeCacheSecurityGroup = "DescribeCacheSecurityGroup"
+const opDescribeInstances = "DescribeInstances"
 
-// DescribeCacheSecurityGroupRequest generates a "ksc/request.Request" representing the
-// client's request for the DescribeCacheSecurityGroup operation. The "output" return
+// DescribeInstancesRequest generates a "ksc/request.Request" representing the
+// client's request for the DescribeInstances operation. The "output" return
 // value will be populated with the request's response once the request completes
 // successfully.
 //
 // Use "Send" method on the returned Request to send the API call to the service.
 // the "output" return value is not valid until after Send returns without error.
 //
-// See DescribeCacheSecurityGroup for more information on using the DescribeCacheSecurityGroup
+// See DescribeInstances for more information on using the DescribeInstances
 // API call, and error handling.
 //
 // This method is useful when you want to inject custom logic or configuration
 // into the SDK's request lifecycle. Such as custom headers, or retry logic.
 //
 //
-//    // Example sending a request using the DescribeCacheSecurityGroupRequest method.
-//    req, resp := client.DescribeCacheSecurityGroupRequest(params)
+//    // Example sending a request using the DescribeInstancesRequest method.
+//    req, resp := client.DescribeInstancesRequest(params)
 //
 //    err := req.Send()
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/kcs-2016-07-01/DescribeCacheSecurityGroup
-func (c *Kcsv1) DescribeCacheSecurityGroupRequest(input *map[string]interface{}) (req *request.Request, output *map[string]interface{}) {
+// See also, https://docs.aws.amazon.com/goto/WebAPI/kcs-2016-07-01/DescribeInstances
+func (c *Kcsv1) DescribeInstancesRequest(input *map[string]interface{}) (req *request.Request, output *map[string]interface{}) {
 	op := &request.Operation{
-		Name:       opDescribeCacheSecurityGroup,
+		Name:       opDescribeInstances,
 		HTTPMethod: "GET",
 		HTTPPath:   "/",
 	}
@@ -1291,177 +1510,31 @@ func (c *Kcsv1) DescribeCacheSecurityGroupRequest(input *map[string]interface{})
 	return
 }
 
-// DescribeCacheSecurityGroup API operation for kcsv1.
+// DescribeInstances API operation for kcsv1.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
 // the error.
 //
 // See the KSC API reference guide for kcsv1's
-// API operation DescribeCacheSecurityGroup for usage and error information.
-// See also, https://docs.aws.amazon.com/goto/WebAPI/kcs-2016-07-01/DescribeCacheSecurityGroup
-func (c *Kcsv1) DescribeCacheSecurityGroup(input *map[string]interface{}) (*map[string]interface{}, error) {
-	req, out := c.DescribeCacheSecurityGroupRequest(input)
+// API operation DescribeInstances for usage and error information.
+// See also, https://docs.aws.amazon.com/goto/WebAPI/kcs-2016-07-01/DescribeInstances
+func (c *Kcsv1) DescribeInstances(input *map[string]interface{}) (*map[string]interface{}, error) {
+	req, out := c.DescribeInstancesRequest(input)
 	return out, req.Send()
 }
 
-// DescribeCacheSecurityGroupWithContext is the same as DescribeCacheSecurityGroup with the addition of
+// DescribeInstancesWithContext is the same as DescribeInstances with the addition of
 // the ability to pass a context and additional request options.
 //
-// See DescribeCacheSecurityGroup for details on how to use this API operation.
+// See DescribeInstances for details on how to use this API operation.
 //
 // The context must be non-nil and will be used for request cancellation. If
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *Kcsv1) DescribeCacheSecurityGroupWithContext(ctx aws.Context, input *map[string]interface{}, opts ...request.Option) (*map[string]interface{}, error) {
-	req, out := c.DescribeCacheSecurityGroupRequest(input)
-	req.SetContext(ctx)
-	req.ApplyOptions(opts...)
-	return out, req.Send()
-}
-
-const opDescribeCacheSecurityGroups = "DescribeCacheSecurityGroups"
-
-// DescribeCacheSecurityGroupsRequest generates a "ksc/request.Request" representing the
-// client's request for the DescribeCacheSecurityGroups operation. The "output" return
-// value will be populated with the request's response once the request completes
-// successfully.
-//
-// Use "Send" method on the returned Request to send the API call to the service.
-// the "output" return value is not valid until after Send returns without error.
-//
-// See DescribeCacheSecurityGroups for more information on using the DescribeCacheSecurityGroups
-// API call, and error handling.
-//
-// This method is useful when you want to inject custom logic or configuration
-// into the SDK's request lifecycle. Such as custom headers, or retry logic.
-//
-//
-//    // Example sending a request using the DescribeCacheSecurityGroupsRequest method.
-//    req, resp := client.DescribeCacheSecurityGroupsRequest(params)
-//
-//    err := req.Send()
-//    if err == nil { // resp is now filled
-//        fmt.Println(resp)
-//    }
-//
-// See also, https://docs.aws.amazon.com/goto/WebAPI/kcs-2016-07-01/DescribeCacheSecurityGroups
-func (c *Kcsv1) DescribeCacheSecurityGroupsRequest(input *map[string]interface{}) (req *request.Request, output *map[string]interface{}) {
-	op := &request.Operation{
-		Name:       opDescribeCacheSecurityGroups,
-		HTTPMethod: "GET",
-		HTTPPath:   "/",
-	}
-
-	if input == nil {
-		input = &map[string]interface{}{}
-	}
-
-	output = &map[string]interface{}{}
-	req = c.newRequest(op, input, output)
-
-	return
-}
-
-// DescribeCacheSecurityGroups API operation for kcsv1.
-//
-// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
-// with awserr.Error's Code and Message methods to get detailed information about
-// the error.
-//
-// See the KSC API reference guide for kcsv1's
-// API operation DescribeCacheSecurityGroups for usage and error information.
-// See also, https://docs.aws.amazon.com/goto/WebAPI/kcs-2016-07-01/DescribeCacheSecurityGroups
-func (c *Kcsv1) DescribeCacheSecurityGroups(input *map[string]interface{}) (*map[string]interface{}, error) {
-	req, out := c.DescribeCacheSecurityGroupsRequest(input)
-	return out, req.Send()
-}
-
-// DescribeCacheSecurityGroupsWithContext is the same as DescribeCacheSecurityGroups with the addition of
-// the ability to pass a context and additional request options.
-//
-// See DescribeCacheSecurityGroups for details on how to use this API operation.
-//
-// The context must be non-nil and will be used for request cancellation. If
-// the context is nil a panic will occur. In the future the SDK may create
-// sub-contexts for http.Requests. See https://golang.org/pkg/context/
-// for more information on using Contexts.
-func (c *Kcsv1) DescribeCacheSecurityGroupsWithContext(ctx aws.Context, input *map[string]interface{}, opts ...request.Option) (*map[string]interface{}, error) {
-	req, out := c.DescribeCacheSecurityGroupsRequest(input)
-	req.SetContext(ctx)
-	req.ApplyOptions(opts...)
-	return out, req.Send()
-}
-
-const opDescribeCacheSecurityRules = "DescribeCacheSecurityRules"
-
-// DescribeCacheSecurityRulesRequest generates a "ksc/request.Request" representing the
-// client's request for the DescribeCacheSecurityRules operation. The "output" return
-// value will be populated with the request's response once the request completes
-// successfully.
-//
-// Use "Send" method on the returned Request to send the API call to the service.
-// the "output" return value is not valid until after Send returns without error.
-//
-// See DescribeCacheSecurityRules for more information on using the DescribeCacheSecurityRules
-// API call, and error handling.
-//
-// This method is useful when you want to inject custom logic or configuration
-// into the SDK's request lifecycle. Such as custom headers, or retry logic.
-//
-//
-//    // Example sending a request using the DescribeCacheSecurityRulesRequest method.
-//    req, resp := client.DescribeCacheSecurityRulesRequest(params)
-//
-//    err := req.Send()
-//    if err == nil { // resp is now filled
-//        fmt.Println(resp)
-//    }
-//
-// See also, https://docs.aws.amazon.com/goto/WebAPI/kcs-2016-07-01/DescribeCacheSecurityRules
-func (c *Kcsv1) DescribeCacheSecurityRulesRequest(input *map[string]interface{}) (req *request.Request, output *map[string]interface{}) {
-	op := &request.Operation{
-		Name:       opDescribeCacheSecurityRules,
-		HTTPMethod: "GET",
-		HTTPPath:   "/",
-	}
-
-	if input == nil {
-		input = &map[string]interface{}{}
-	}
-
-	output = &map[string]interface{}{}
-	req = c.newRequest(op, input, output)
-
-	return
-}
-
-// DescribeCacheSecurityRules API operation for kcsv1.
-//
-// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
-// with awserr.Error's Code and Message methods to get detailed information about
-// the error.
-//
-// See the KSC API reference guide for kcsv1's
-// API operation DescribeCacheSecurityRules for usage and error information.
-// See also, https://docs.aws.amazon.com/goto/WebAPI/kcs-2016-07-01/DescribeCacheSecurityRules
-func (c *Kcsv1) DescribeCacheSecurityRules(input *map[string]interface{}) (*map[string]interface{}, error) {
-	req, out := c.DescribeCacheSecurityRulesRequest(input)
-	return out, req.Send()
-}
-
-// DescribeCacheSecurityRulesWithContext is the same as DescribeCacheSecurityRules with the addition of
-// the ability to pass a context and additional request options.
-//
-// See DescribeCacheSecurityRules for details on how to use this API operation.
-//
-// The context must be non-nil and will be used for request cancellation. If
-// the context is nil a panic will occur. In the future the SDK may create
-// sub-contexts for http.Requests. See https://golang.org/pkg/context/
-// for more information on using Contexts.
-func (c *Kcsv1) DescribeCacheSecurityRulesWithContext(ctx aws.Context, input *map[string]interface{}, opts ...request.Option) (*map[string]interface{}, error) {
-	req, out := c.DescribeCacheSecurityRulesRequest(input)
+func (c *Kcsv1) DescribeInstancesWithContext(ctx aws.Context, input *map[string]interface{}, opts ...request.Option) (*map[string]interface{}, error) {
+	req, out := c.DescribeInstancesRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -1535,6 +1608,152 @@ func (c *Kcsv1) DescribeRegions(input *map[string]interface{}) (*map[string]inte
 // for more information on using Contexts.
 func (c *Kcsv1) DescribeRegionsWithContext(ctx aws.Context, input *map[string]interface{}, opts ...request.Option) (*map[string]interface{}, error) {
 	req, out := c.DescribeRegionsRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opDescribeSecurityGroup = "DescribeSecurityGroup"
+
+// DescribeSecurityGroupRequest generates a "ksc/request.Request" representing the
+// client's request for the DescribeSecurityGroup operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DescribeSecurityGroup for more information on using the DescribeSecurityGroup
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DescribeSecurityGroupRequest method.
+//    req, resp := client.DescribeSecurityGroupRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/kcs-2016-07-01/DescribeSecurityGroup
+func (c *Kcsv1) DescribeSecurityGroupRequest(input *map[string]interface{}) (req *request.Request, output *map[string]interface{}) {
+	op := &request.Operation{
+		Name:       opDescribeSecurityGroup,
+		HTTPMethod: "GET",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &map[string]interface{}{}
+	}
+
+	output = &map[string]interface{}{}
+	req = c.newRequest(op, input, output)
+
+	return
+}
+
+// DescribeSecurityGroup API operation for kcsv1.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the KSC API reference guide for kcsv1's
+// API operation DescribeSecurityGroup for usage and error information.
+// See also, https://docs.aws.amazon.com/goto/WebAPI/kcs-2016-07-01/DescribeSecurityGroup
+func (c *Kcsv1) DescribeSecurityGroup(input *map[string]interface{}) (*map[string]interface{}, error) {
+	req, out := c.DescribeSecurityGroupRequest(input)
+	return out, req.Send()
+}
+
+// DescribeSecurityGroupWithContext is the same as DescribeSecurityGroup with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DescribeSecurityGroup for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *Kcsv1) DescribeSecurityGroupWithContext(ctx aws.Context, input *map[string]interface{}, opts ...request.Option) (*map[string]interface{}, error) {
+	req, out := c.DescribeSecurityGroupRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opDescribeSecurityGroups = "DescribeSecurityGroups"
+
+// DescribeSecurityGroupsRequest generates a "ksc/request.Request" representing the
+// client's request for the DescribeSecurityGroups operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DescribeSecurityGroups for more information on using the DescribeSecurityGroups
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DescribeSecurityGroupsRequest method.
+//    req, resp := client.DescribeSecurityGroupsRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/kcs-2016-07-01/DescribeSecurityGroups
+func (c *Kcsv1) DescribeSecurityGroupsRequest(input *map[string]interface{}) (req *request.Request, output *map[string]interface{}) {
+	op := &request.Operation{
+		Name:       opDescribeSecurityGroups,
+		HTTPMethod: "GET",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &map[string]interface{}{}
+	}
+
+	output = &map[string]interface{}{}
+	req = c.newRequest(op, input, output)
+
+	return
+}
+
+// DescribeSecurityGroups API operation for kcsv1.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the KSC API reference guide for kcsv1's
+// API operation DescribeSecurityGroups for usage and error information.
+// See also, https://docs.aws.amazon.com/goto/WebAPI/kcs-2016-07-01/DescribeSecurityGroups
+func (c *Kcsv1) DescribeSecurityGroups(input *map[string]interface{}) (*map[string]interface{}, error) {
+	req, out := c.DescribeSecurityGroupsRequest(input)
+	return out, req.Send()
+}
+
+// DescribeSecurityGroupsWithContext is the same as DescribeSecurityGroups with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DescribeSecurityGroups for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *Kcsv1) DescribeSecurityGroupsWithContext(ctx aws.Context, input *map[string]interface{}, opts ...request.Option) (*map[string]interface{}, error) {
+	req, out := c.DescribeSecurityGroupsRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -1905,36 +2124,36 @@ func (c *Kcsv1) ModifyCacheParameterGroupWithContext(ctx aws.Context, input *map
 	return out, req.Send()
 }
 
-const opModifyCacheSecurityGroup = "ModifyCacheSecurityGroup"
+const opModifySecurityGroup = "ModifySecurityGroup"
 
-// ModifyCacheSecurityGroupRequest generates a "ksc/request.Request" representing the
-// client's request for the ModifyCacheSecurityGroup operation. The "output" return
+// ModifySecurityGroupRequest generates a "ksc/request.Request" representing the
+// client's request for the ModifySecurityGroup operation. The "output" return
 // value will be populated with the request's response once the request completes
 // successfully.
 //
 // Use "Send" method on the returned Request to send the API call to the service.
 // the "output" return value is not valid until after Send returns without error.
 //
-// See ModifyCacheSecurityGroup for more information on using the ModifyCacheSecurityGroup
+// See ModifySecurityGroup for more information on using the ModifySecurityGroup
 // API call, and error handling.
 //
 // This method is useful when you want to inject custom logic or configuration
 // into the SDK's request lifecycle. Such as custom headers, or retry logic.
 //
 //
-//    // Example sending a request using the ModifyCacheSecurityGroupRequest method.
-//    req, resp := client.ModifyCacheSecurityGroupRequest(params)
+//    // Example sending a request using the ModifySecurityGroupRequest method.
+//    req, resp := client.ModifySecurityGroupRequest(params)
 //
 //    err := req.Send()
 //    if err == nil { // resp is now filled
 //        fmt.Println(resp)
 //    }
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/kcs-2016-07-01/ModifyCacheSecurityGroup
-func (c *Kcsv1) ModifyCacheSecurityGroupRequest(input *map[string]interface{}) (req *request.Request, output *map[string]interface{}) {
+// See also, https://docs.aws.amazon.com/goto/WebAPI/kcs-2016-07-01/ModifySecurityGroup
+func (c *Kcsv1) ModifySecurityGroupRequest(input *map[string]interface{}) (req *request.Request, output *map[string]interface{}) {
 	op := &request.Operation{
-		Name:       opModifyCacheSecurityGroup,
-		HTTPMethod: "PUT",
+		Name:       opModifySecurityGroup,
+		HTTPMethod: "POST",
 		HTTPPath:   "/",
 	}
 
@@ -1948,31 +2167,31 @@ func (c *Kcsv1) ModifyCacheSecurityGroupRequest(input *map[string]interface{}) (
 	return
 }
 
-// ModifyCacheSecurityGroup API operation for kcsv1.
+// ModifySecurityGroup API operation for kcsv1.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
 // the error.
 //
 // See the KSC API reference guide for kcsv1's
-// API operation ModifyCacheSecurityGroup for usage and error information.
-// See also, https://docs.aws.amazon.com/goto/WebAPI/kcs-2016-07-01/ModifyCacheSecurityGroup
-func (c *Kcsv1) ModifyCacheSecurityGroup(input *map[string]interface{}) (*map[string]interface{}, error) {
-	req, out := c.ModifyCacheSecurityGroupRequest(input)
+// API operation ModifySecurityGroup for usage and error information.
+// See also, https://docs.aws.amazon.com/goto/WebAPI/kcs-2016-07-01/ModifySecurityGroup
+func (c *Kcsv1) ModifySecurityGroup(input *map[string]interface{}) (*map[string]interface{}, error) {
+	req, out := c.ModifySecurityGroupRequest(input)
 	return out, req.Send()
 }
 
-// ModifyCacheSecurityGroupWithContext is the same as ModifyCacheSecurityGroup with the addition of
+// ModifySecurityGroupWithContext is the same as ModifySecurityGroup with the addition of
 // the ability to pass a context and additional request options.
 //
-// See ModifyCacheSecurityGroup for details on how to use this API operation.
+// See ModifySecurityGroup for details on how to use this API operation.
 //
 // The context must be non-nil and will be used for request cancellation. If
 // the context is nil a panic will occur. In the future the SDK may create
 // sub-contexts for http.Requests. See https://golang.org/pkg/context/
 // for more information on using Contexts.
-func (c *Kcsv1) ModifyCacheSecurityGroupWithContext(ctx aws.Context, input *map[string]interface{}, opts ...request.Option) (*map[string]interface{}, error) {
-	req, out := c.ModifyCacheSecurityGroupRequest(input)
+func (c *Kcsv1) ModifySecurityGroupWithContext(ctx aws.Context, input *map[string]interface{}, opts ...request.Option) (*map[string]interface{}, error) {
+	req, out := c.ModifySecurityGroupRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -2411,152 +2630,6 @@ func (c *Kcsv1) SetCacheParameters(input *map[string]interface{}) (*map[string]i
 // for more information on using Contexts.
 func (c *Kcsv1) SetCacheParametersWithContext(ctx aws.Context, input *map[string]interface{}, opts ...request.Option) (*map[string]interface{}, error) {
 	req, out := c.SetCacheParametersRequest(input)
-	req.SetContext(ctx)
-	req.ApplyOptions(opts...)
-	return out, req.Send()
-}
-
-const opSetCacheSecurityGroup = "SetCacheSecurityGroup"
-
-// SetCacheSecurityGroupRequest generates a "ksc/request.Request" representing the
-// client's request for the SetCacheSecurityGroup operation. The "output" return
-// value will be populated with the request's response once the request completes
-// successfully.
-//
-// Use "Send" method on the returned Request to send the API call to the service.
-// the "output" return value is not valid until after Send returns without error.
-//
-// See SetCacheSecurityGroup for more information on using the SetCacheSecurityGroup
-// API call, and error handling.
-//
-// This method is useful when you want to inject custom logic or configuration
-// into the SDK's request lifecycle. Such as custom headers, or retry logic.
-//
-//
-//    // Example sending a request using the SetCacheSecurityGroupRequest method.
-//    req, resp := client.SetCacheSecurityGroupRequest(params)
-//
-//    err := req.Send()
-//    if err == nil { // resp is now filled
-//        fmt.Println(resp)
-//    }
-//
-// See also, https://docs.aws.amazon.com/goto/WebAPI/kcs-2016-07-01/SetCacheSecurityGroup
-func (c *Kcsv1) SetCacheSecurityGroupRequest(input *map[string]interface{}) (req *request.Request, output *map[string]interface{}) {
-	op := &request.Operation{
-		Name:       opSetCacheSecurityGroup,
-		HTTPMethod: "PUT",
-		HTTPPath:   "/",
-	}
-
-	if input == nil {
-		input = &map[string]interface{}{}
-	}
-
-	output = &map[string]interface{}{}
-	req = c.newRequest(op, input, output)
-
-	return
-}
-
-// SetCacheSecurityGroup API operation for kcsv1.
-//
-// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
-// with awserr.Error's Code and Message methods to get detailed information about
-// the error.
-//
-// See the KSC API reference guide for kcsv1's
-// API operation SetCacheSecurityGroup for usage and error information.
-// See also, https://docs.aws.amazon.com/goto/WebAPI/kcs-2016-07-01/SetCacheSecurityGroup
-func (c *Kcsv1) SetCacheSecurityGroup(input *map[string]interface{}) (*map[string]interface{}, error) {
-	req, out := c.SetCacheSecurityGroupRequest(input)
-	return out, req.Send()
-}
-
-// SetCacheSecurityGroupWithContext is the same as SetCacheSecurityGroup with the addition of
-// the ability to pass a context and additional request options.
-//
-// See SetCacheSecurityGroup for details on how to use this API operation.
-//
-// The context must be non-nil and will be used for request cancellation. If
-// the context is nil a panic will occur. In the future the SDK may create
-// sub-contexts for http.Requests. See https://golang.org/pkg/context/
-// for more information on using Contexts.
-func (c *Kcsv1) SetCacheSecurityGroupWithContext(ctx aws.Context, input *map[string]interface{}, opts ...request.Option) (*map[string]interface{}, error) {
-	req, out := c.SetCacheSecurityGroupRequest(input)
-	req.SetContext(ctx)
-	req.ApplyOptions(opts...)
-	return out, req.Send()
-}
-
-const opSetCacheSecurityRules = "SetCacheSecurityRules"
-
-// SetCacheSecurityRulesRequest generates a "ksc/request.Request" representing the
-// client's request for the SetCacheSecurityRules operation. The "output" return
-// value will be populated with the request's response once the request completes
-// successfully.
-//
-// Use "Send" method on the returned Request to send the API call to the service.
-// the "output" return value is not valid until after Send returns without error.
-//
-// See SetCacheSecurityRules for more information on using the SetCacheSecurityRules
-// API call, and error handling.
-//
-// This method is useful when you want to inject custom logic or configuration
-// into the SDK's request lifecycle. Such as custom headers, or retry logic.
-//
-//
-//    // Example sending a request using the SetCacheSecurityRulesRequest method.
-//    req, resp := client.SetCacheSecurityRulesRequest(params)
-//
-//    err := req.Send()
-//    if err == nil { // resp is now filled
-//        fmt.Println(resp)
-//    }
-//
-// See also, https://docs.aws.amazon.com/goto/WebAPI/kcs-2016-07-01/SetCacheSecurityRules
-func (c *Kcsv1) SetCacheSecurityRulesRequest(input *map[string]interface{}) (req *request.Request, output *map[string]interface{}) {
-	op := &request.Operation{
-		Name:       opSetCacheSecurityRules,
-		HTTPMethod: "PUT",
-		HTTPPath:   "/",
-	}
-
-	if input == nil {
-		input = &map[string]interface{}{}
-	}
-
-	output = &map[string]interface{}{}
-	req = c.newRequest(op, input, output)
-
-	return
-}
-
-// SetCacheSecurityRules API operation for kcsv1.
-//
-// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
-// with awserr.Error's Code and Message methods to get detailed information about
-// the error.
-//
-// See the KSC API reference guide for kcsv1's
-// API operation SetCacheSecurityRules for usage and error information.
-// See also, https://docs.aws.amazon.com/goto/WebAPI/kcs-2016-07-01/SetCacheSecurityRules
-func (c *Kcsv1) SetCacheSecurityRules(input *map[string]interface{}) (*map[string]interface{}, error) {
-	req, out := c.SetCacheSecurityRulesRequest(input)
-	return out, req.Send()
-}
-
-// SetCacheSecurityRulesWithContext is the same as SetCacheSecurityRules with the addition of
-// the ability to pass a context and additional request options.
-//
-// See SetCacheSecurityRules for details on how to use this API operation.
-//
-// The context must be non-nil and will be used for request cancellation. If
-// the context is nil a panic will occur. In the future the SDK may create
-// sub-contexts for http.Requests. See https://golang.org/pkg/context/
-// for more information on using Contexts.
-func (c *Kcsv1) SetCacheSecurityRulesWithContext(ctx aws.Context, input *map[string]interface{}, opts ...request.Option) (*map[string]interface{}, error) {
-	req, out := c.SetCacheSecurityRulesRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()

--- a/service/kcsv1/kcsv1iface/interface.go
+++ b/service/kcsv1/kcsv1iface/interface.go
@@ -26,7 +26,7 @@ import (
 //    // myFunc uses an SDK service client to make a request to
 //    // kcsv1.
 //    func myFunc(svc kcsv1iface.Kcsv1API) bool {
-//        // Make svc.CreateCacheCluster request
+//        // Make svc.AllocateSecurityGroup request
 //    }
 //
 //    func main() {
@@ -42,7 +42,7 @@ import (
 //    type mockKcsv1Client struct {
 //        kcsv1iface.Kcsv1API
 //    }
-//    func (m *mockKcsv1Client) CreateCacheCluster(input *map[string]interface{}) (*map[string]interface{}, error) {
+//    func (m *mockKcsv1Client) AllocateSecurityGroup(input *map[string]interface{}) (*map[string]interface{}, error) {
 //        // mock response/functionality
 //    }
 //
@@ -60,6 +60,14 @@ import (
 // and waiters. Its suggested to use the pattern above for testing, or using
 // tooling to generate mocks to satisfy the interfaces.
 type Kcsv1API interface {
+	AllocateSecurityGroup(*map[string]interface{}) (*map[string]interface{}, error)
+	AllocateSecurityGroupWithContext(aws.Context, *map[string]interface{}, ...request.Option) (*map[string]interface{}, error)
+	AllocateSecurityGroupRequest(*map[string]interface{}) (*request.Request, *map[string]interface{})
+
+	CloneSecurityGroup(*map[string]interface{}) (*map[string]interface{}, error)
+	CloneSecurityGroupWithContext(aws.Context, *map[string]interface{}, ...request.Option) (*map[string]interface{}, error)
+	CloneSecurityGroupRequest(*map[string]interface{}) (*request.Request, *map[string]interface{})
+
 	CreateCacheCluster(*map[string]interface{}) (*map[string]interface{}, error)
 	CreateCacheClusterWithContext(aws.Context, *map[string]interface{}, ...request.Option) (*map[string]interface{}, error)
 	CreateCacheClusterRequest(*map[string]interface{}) (*request.Request, *map[string]interface{})
@@ -68,13 +76,21 @@ type Kcsv1API interface {
 	CreateCacheParameterGroupWithContext(aws.Context, *map[string]interface{}, ...request.Option) (*map[string]interface{}, error)
 	CreateCacheParameterGroupRequest(*map[string]interface{}) (*request.Request, *map[string]interface{})
 
-	CreateCacheSecurityGroup(*map[string]interface{}) (*map[string]interface{}, error)
-	CreateCacheSecurityGroupWithContext(aws.Context, *map[string]interface{}, ...request.Option) (*map[string]interface{}, error)
-	CreateCacheSecurityGroupRequest(*map[string]interface{}) (*request.Request, *map[string]interface{})
+	CreateSecurityGroup(*map[string]interface{}) (*map[string]interface{}, error)
+	CreateSecurityGroupWithContext(aws.Context, *map[string]interface{}, ...request.Option) (*map[string]interface{}, error)
+	CreateSecurityGroupRequest(*map[string]interface{}) (*request.Request, *map[string]interface{})
+
+	CreateSecurityGroupRule(*map[string]interface{}) (*map[string]interface{}, error)
+	CreateSecurityGroupRuleWithContext(aws.Context, *map[string]interface{}, ...request.Option) (*map[string]interface{}, error)
+	CreateSecurityGroupRuleRequest(*map[string]interface{}) (*request.Request, *map[string]interface{})
 
 	CreateSnapshot(*map[string]interface{}) (*map[string]interface{}, error)
 	CreateSnapshotWithContext(aws.Context, *map[string]interface{}, ...request.Option) (*map[string]interface{}, error)
 	CreateSnapshotRequest(*map[string]interface{}) (*request.Request, *map[string]interface{})
+
+	DeallocateSecurityGroup(*map[string]interface{}) (*map[string]interface{}, error)
+	DeallocateSecurityGroupWithContext(aws.Context, *map[string]interface{}, ...request.Option) (*map[string]interface{}, error)
+	DeallocateSecurityGroupRequest(*map[string]interface{}) (*request.Request, *map[string]interface{})
 
 	DeleteCacheCluster(*map[string]interface{}) (*map[string]interface{}, error)
 	DeleteCacheClusterWithContext(aws.Context, *map[string]interface{}, ...request.Option) (*map[string]interface{}, error)
@@ -84,17 +100,13 @@ type Kcsv1API interface {
 	DeleteCacheParameterGroupWithContext(aws.Context, *map[string]interface{}, ...request.Option) (*map[string]interface{}, error)
 	DeleteCacheParameterGroupRequest(*map[string]interface{}) (*request.Request, *map[string]interface{})
 
-	DeleteCacheSecurityGroup(*map[string]interface{}) (*map[string]interface{}, error)
-	DeleteCacheSecurityGroupWithContext(aws.Context, *map[string]interface{}, ...request.Option) (*map[string]interface{}, error)
-	DeleteCacheSecurityGroupRequest(*map[string]interface{}) (*request.Request, *map[string]interface{})
+	DeleteSecurityGroup(*map[string]interface{}) (*map[string]interface{}, error)
+	DeleteSecurityGroupWithContext(aws.Context, *map[string]interface{}, ...request.Option) (*map[string]interface{}, error)
+	DeleteSecurityGroupRequest(*map[string]interface{}) (*request.Request, *map[string]interface{})
 
-	DeleteCacheSecurityGroupRule(*map[string]interface{}) (*map[string]interface{}, error)
-	DeleteCacheSecurityGroupRuleWithContext(aws.Context, *map[string]interface{}, ...request.Option) (*map[string]interface{}, error)
-	DeleteCacheSecurityGroupRuleRequest(*map[string]interface{}) (*request.Request, *map[string]interface{})
-
-	DeleteCacheSecurityRule(*map[string]interface{}) (*map[string]interface{}, error)
-	DeleteCacheSecurityRuleWithContext(aws.Context, *map[string]interface{}, ...request.Option) (*map[string]interface{}, error)
-	DeleteCacheSecurityRuleRequest(*map[string]interface{}) (*request.Request, *map[string]interface{})
+	DeleteSecurityGroupRule(*map[string]interface{}) (*map[string]interface{}, error)
+	DeleteSecurityGroupRuleWithContext(aws.Context, *map[string]interface{}, ...request.Option) (*map[string]interface{}, error)
+	DeleteSecurityGroupRuleRequest(*map[string]interface{}) (*request.Request, *map[string]interface{})
 
 	DeleteSnapshot(*map[string]interface{}) (*map[string]interface{}, error)
 	DeleteSnapshotWithContext(aws.Context, *map[string]interface{}, ...request.Option) (*map[string]interface{}, error)
@@ -128,21 +140,21 @@ type Kcsv1API interface {
 	DescribeCacheParametersWithContext(aws.Context, *map[string]interface{}, ...request.Option) (*map[string]interface{}, error)
 	DescribeCacheParametersRequest(*map[string]interface{}) (*request.Request, *map[string]interface{})
 
-	DescribeCacheSecurityGroup(*map[string]interface{}) (*map[string]interface{}, error)
-	DescribeCacheSecurityGroupWithContext(aws.Context, *map[string]interface{}, ...request.Option) (*map[string]interface{}, error)
-	DescribeCacheSecurityGroupRequest(*map[string]interface{}) (*request.Request, *map[string]interface{})
-
-	DescribeCacheSecurityGroups(*map[string]interface{}) (*map[string]interface{}, error)
-	DescribeCacheSecurityGroupsWithContext(aws.Context, *map[string]interface{}, ...request.Option) (*map[string]interface{}, error)
-	DescribeCacheSecurityGroupsRequest(*map[string]interface{}) (*request.Request, *map[string]interface{})
-
-	DescribeCacheSecurityRules(*map[string]interface{}) (*map[string]interface{}, error)
-	DescribeCacheSecurityRulesWithContext(aws.Context, *map[string]interface{}, ...request.Option) (*map[string]interface{}, error)
-	DescribeCacheSecurityRulesRequest(*map[string]interface{}) (*request.Request, *map[string]interface{})
+	DescribeInstances(*map[string]interface{}) (*map[string]interface{}, error)
+	DescribeInstancesWithContext(aws.Context, *map[string]interface{}, ...request.Option) (*map[string]interface{}, error)
+	DescribeInstancesRequest(*map[string]interface{}) (*request.Request, *map[string]interface{})
 
 	DescribeRegions(*map[string]interface{}) (*map[string]interface{}, error)
 	DescribeRegionsWithContext(aws.Context, *map[string]interface{}, ...request.Option) (*map[string]interface{}, error)
 	DescribeRegionsRequest(*map[string]interface{}) (*request.Request, *map[string]interface{})
+
+	DescribeSecurityGroup(*map[string]interface{}) (*map[string]interface{}, error)
+	DescribeSecurityGroupWithContext(aws.Context, *map[string]interface{}, ...request.Option) (*map[string]interface{}, error)
+	DescribeSecurityGroupRequest(*map[string]interface{}) (*request.Request, *map[string]interface{})
+
+	DescribeSecurityGroups(*map[string]interface{}) (*map[string]interface{}, error)
+	DescribeSecurityGroupsWithContext(aws.Context, *map[string]interface{}, ...request.Option) (*map[string]interface{}, error)
+	DescribeSecurityGroupsRequest(*map[string]interface{}) (*request.Request, *map[string]interface{})
 
 	DescribeSnapshots(*map[string]interface{}) (*map[string]interface{}, error)
 	DescribeSnapshotsWithContext(aws.Context, *map[string]interface{}, ...request.Option) (*map[string]interface{}, error)
@@ -164,9 +176,9 @@ type Kcsv1API interface {
 	ModifyCacheParameterGroupWithContext(aws.Context, *map[string]interface{}, ...request.Option) (*map[string]interface{}, error)
 	ModifyCacheParameterGroupRequest(*map[string]interface{}) (*request.Request, *map[string]interface{})
 
-	ModifyCacheSecurityGroup(*map[string]interface{}) (*map[string]interface{}, error)
-	ModifyCacheSecurityGroupWithContext(aws.Context, *map[string]interface{}, ...request.Option) (*map[string]interface{}, error)
-	ModifyCacheSecurityGroupRequest(*map[string]interface{}) (*request.Request, *map[string]interface{})
+	ModifySecurityGroup(*map[string]interface{}) (*map[string]interface{}, error)
+	ModifySecurityGroupWithContext(aws.Context, *map[string]interface{}, ...request.Option) (*map[string]interface{}, error)
+	ModifySecurityGroupRequest(*map[string]interface{}) (*request.Request, *map[string]interface{})
 
 	RenameCacheCluster(*map[string]interface{}) (*map[string]interface{}, error)
 	RenameCacheClusterWithContext(aws.Context, *map[string]interface{}, ...request.Option) (*map[string]interface{}, error)
@@ -191,14 +203,6 @@ type Kcsv1API interface {
 	SetCacheParameters(*map[string]interface{}) (*map[string]interface{}, error)
 	SetCacheParametersWithContext(aws.Context, *map[string]interface{}, ...request.Option) (*map[string]interface{}, error)
 	SetCacheParametersRequest(*map[string]interface{}) (*request.Request, *map[string]interface{})
-
-	SetCacheSecurityGroup(*map[string]interface{}) (*map[string]interface{}, error)
-	SetCacheSecurityGroupWithContext(aws.Context, *map[string]interface{}, ...request.Option) (*map[string]interface{}, error)
-	SetCacheSecurityGroupRequest(*map[string]interface{}) (*request.Request, *map[string]interface{})
-
-	SetCacheSecurityRules(*map[string]interface{}) (*map[string]interface{}, error)
-	SetCacheSecurityRulesWithContext(aws.Context, *map[string]interface{}, ...request.Option) (*map[string]interface{}, error)
-	SetCacheSecurityRulesRequest(*map[string]interface{}) (*request.Request, *map[string]interface{})
 
 	SetTimingSnapshot(*map[string]interface{}) (*map[string]interface{}, error)
 	SetTimingSnapshotWithContext(aws.Context, *map[string]interface{}, ...request.Option) (*map[string]interface{}, error)


### PR DESCRIPTION
Redis discards the old set of interfaces for binding instances with security group rules and adds a set of interfaces for binding instances with security group rulesadd redis security groupd.